### PR TITLE
Display part of speech in definition tiles

### DIFF
--- a/lib/notebooks/definition_tile.dart
+++ b/lib/notebooks/definition_tile.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:orditori/swagger_generated_code/orditori.swagger.dart';
 
@@ -31,9 +32,22 @@ class DefinitionTile extends StatelessWidget {
               children: [
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 15.0),
-                  child: SelectableText(
-                    def.word!,
-                    style: textTheme.titleSmall,
+                  child: Wrap(
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    children: [
+                      SelectableText(
+                        def.word!,
+                        style: textTheme.titleSmall,
+                      ),
+                      if (def.partOfSpeech != null &&
+                          def.partOfSpeech !=
+                              PartOfSpeech.swaggerGeneratedUnknown)
+                        Text(
+                          describeEnum(def.partOfSpeech!),
+                          style: textTheme.bodySmall!
+                              .copyWith(fontStyle: FontStyle.italic),
+                        )
+                    ],
                   ),
                 ),
                 SelectableText(

--- a/lib/orditori.json
+++ b/lib/orditori.json
@@ -573,6 +573,9 @@
             "type": "integer",
             "minimum": -9223372036854775808
           },
+          "partOfSpeech": {
+            "$ref": "#/components/schemas/PartOfSpeech"
+          },
           "word": {
             "type": "string"
           },
@@ -596,6 +599,20 @@
           "examples"
         ],
         "description": "A notebook entry definition item"
+      },
+      "PartOfSpeech": {
+        "type": "string",
+        "enum": [
+          "Noun",
+          "Verb",
+          "Adjective",
+          "Adverb",
+          "Pronoun",
+          "Preposition",
+          "Conjunction",
+          "Interjection",
+          "Article"
+        ]
       },
       "Language": {
         "type": "object",
@@ -685,6 +702,9 @@
           },
           "sourceLink": {
             "type": "string"
+          },
+          "partOfSpeech": {
+            "$ref": "#/components/schemas/PartOfSpeech"
           },
           "word": {
             "type": "string"
@@ -783,6 +803,9 @@
             "maximum": 9223372036854775807,
             "type": "integer",
             "minimum": -9223372036854775808
+          },
+          "partOfSpeech": {
+            "$ref": "#/components/schemas/PartOfSpeech"
           },
           "word": {
             "type": "string"
@@ -1040,6 +1063,9 @@
             "maximum": 9223372036854775807,
             "type": "integer",
             "minimum": -9223372036854775808
+          },
+          "partOfSpeech": {
+            "$ref": "#/components/schemas/PartOfSpeech"
           },
           "word": {
             "type": "string"

--- a/lib/swagger_generated_code/orditori.enums.swagger.dart
+++ b/lib/swagger_generated_code/orditori.enums.swagger.dart
@@ -1,0 +1,36 @@
+import 'package:json_annotation/json_annotation.dart';
+
+enum PartOfSpeech {
+  @JsonValue('swaggerGeneratedUnknown')
+  swaggerGeneratedUnknown,
+  @JsonValue('Noun')
+  noun,
+  @JsonValue('Verb')
+  verb,
+  @JsonValue('Adjective')
+  adjective,
+  @JsonValue('Adverb')
+  adverb,
+  @JsonValue('Pronoun')
+  pronoun,
+  @JsonValue('Preposition')
+  preposition,
+  @JsonValue('Conjunction')
+  conjunction,
+  @JsonValue('Interjection')
+  interjection,
+  @JsonValue('Article')
+  article
+}
+
+const $PartOfSpeechMap = {
+  PartOfSpeech.noun: 'Noun',
+  PartOfSpeech.verb: 'Verb',
+  PartOfSpeech.adjective: 'Adjective',
+  PartOfSpeech.adverb: 'Adverb',
+  PartOfSpeech.pronoun: 'Pronoun',
+  PartOfSpeech.preposition: 'Preposition',
+  PartOfSpeech.conjunction: 'Conjunction',
+  PartOfSpeech.interjection: 'Interjection',
+  PartOfSpeech.article: 'Article'
+};

--- a/lib/swagger_generated_code/orditori.swagger.dart
+++ b/lib/swagger_generated_code/orditori.swagger.dart
@@ -4,6 +4,8 @@ import 'package:collection/collection.dart';
 import 'package:chopper/chopper.dart';
 import 'client_mapping.dart';
 import 'package:chopper/chopper.dart' as chopper;
+import 'orditori.enums.swagger.dart' as enums;
+export 'orditori.enums.swagger.dart';
 
 part 'orditori.swagger.chopper.dart';
 part 'orditori.swagger.g.dart';
@@ -373,6 +375,7 @@ class DefinitionContentItemR {
     this.id,
     this.sourceLink,
     this.definitionSource,
+    this.partOfSpeech,
     this.word,
     this.definition,
     this.examples,
@@ -389,6 +392,11 @@ class DefinitionContentItemR {
   final String? sourceLink;
   @JsonKey(name: 'definitionSource')
   final int? definitionSource;
+  @JsonKey(
+      name: 'partOfSpeech',
+      toJson: partOfSpeechToJson,
+      fromJson: partOfSpeechFromJson)
+  final enums.PartOfSpeech? partOfSpeech;
   @JsonKey(name: 'word')
   final String? word;
   @JsonKey(name: 'definition')
@@ -414,6 +422,9 @@ class DefinitionContentItemR {
             (identical(other.definitionSource, definitionSource) ||
                 const DeepCollectionEquality()
                     .equals(other.definitionSource, definitionSource)) &&
+            (identical(other.partOfSpeech, partOfSpeech) ||
+                const DeepCollectionEquality()
+                    .equals(other.partOfSpeech, partOfSpeech)) &&
             (identical(other.word, word) ||
                 const DeepCollectionEquality().equals(other.word, word)) &&
             (identical(other.definition, definition) ||
@@ -430,6 +441,7 @@ class DefinitionContentItemR {
       const DeepCollectionEquality().hash(id) ^
       const DeepCollectionEquality().hash(sourceLink) ^
       const DeepCollectionEquality().hash(definitionSource) ^
+      const DeepCollectionEquality().hash(partOfSpeech) ^
       const DeepCollectionEquality().hash(word) ^
       const DeepCollectionEquality().hash(definition) ^
       const DeepCollectionEquality().hash(examples) ^
@@ -442,6 +454,7 @@ extension $DefinitionContentItemRExtension on DefinitionContentItemR {
       int? id,
       String? sourceLink,
       int? definitionSource,
+      enums.PartOfSpeech? partOfSpeech,
       String? word,
       String? definition,
       List<DefinitionExample>? examples}) {
@@ -450,6 +463,7 @@ extension $DefinitionContentItemRExtension on DefinitionContentItemR {
         id: id ?? this.id,
         sourceLink: sourceLink ?? this.sourceLink,
         definitionSource: definitionSource ?? this.definitionSource,
+        partOfSpeech: partOfSpeech ?? this.partOfSpeech,
         word: word ?? this.word,
         definition: definition ?? this.definition,
         examples: examples ?? this.examples);
@@ -653,6 +667,7 @@ class Definition {
   Definition({
     this.language,
     this.sourceLink,
+    this.partOfSpeech,
     this.word,
     this.definition,
     this.examples,
@@ -665,6 +680,11 @@ class Definition {
   final Language? language;
   @JsonKey(name: 'sourceLink')
   final String? sourceLink;
+  @JsonKey(
+      name: 'partOfSpeech',
+      toJson: partOfSpeechToJson,
+      fromJson: partOfSpeechFromJson)
+  final enums.PartOfSpeech? partOfSpeech;
   @JsonKey(name: 'word')
   final String? word;
   @JsonKey(name: 'definition')
@@ -685,6 +705,9 @@ class Definition {
             (identical(other.sourceLink, sourceLink) ||
                 const DeepCollectionEquality()
                     .equals(other.sourceLink, sourceLink)) &&
+            (identical(other.partOfSpeech, partOfSpeech) ||
+                const DeepCollectionEquality()
+                    .equals(other.partOfSpeech, partOfSpeech)) &&
             (identical(other.word, word) ||
                 const DeepCollectionEquality().equals(other.word, word)) &&
             (identical(other.definition, definition) ||
@@ -699,6 +722,7 @@ class Definition {
   int get hashCode =>
       const DeepCollectionEquality().hash(language) ^
       const DeepCollectionEquality().hash(sourceLink) ^
+      const DeepCollectionEquality().hash(partOfSpeech) ^
       const DeepCollectionEquality().hash(word) ^
       const DeepCollectionEquality().hash(definition) ^
       const DeepCollectionEquality().hash(examples) ^
@@ -709,12 +733,14 @@ extension $DefinitionExtension on Definition {
   Definition copyWith(
       {Language? language,
       String? sourceLink,
+      enums.PartOfSpeech? partOfSpeech,
       String? word,
       String? definition,
       List<Example>? examples}) {
     return Definition(
         language: language ?? this.language,
         sourceLink: sourceLink ?? this.sourceLink,
+        partOfSpeech: partOfSpeech ?? this.partOfSpeech,
         word: word ?? this.word,
         definition: definition ?? this.definition,
         examples: examples ?? this.examples);
@@ -884,6 +910,7 @@ class DefinitionContentItemW {
     this.language,
     this.sourceLink,
     this.definitionSource,
+    this.partOfSpeech,
     this.word,
     this.definition,
     this.entry,
@@ -898,6 +925,11 @@ class DefinitionContentItemW {
   final String? sourceLink;
   @JsonKey(name: 'definitionSource')
   final int? definitionSource;
+  @JsonKey(
+      name: 'partOfSpeech',
+      toJson: partOfSpeechToJson,
+      fromJson: partOfSpeechFromJson)
+  final enums.PartOfSpeech? partOfSpeech;
   @JsonKey(name: 'word')
   final String? word;
   @JsonKey(name: 'definition')
@@ -921,6 +953,9 @@ class DefinitionContentItemW {
             (identical(other.definitionSource, definitionSource) ||
                 const DeepCollectionEquality()
                     .equals(other.definitionSource, definitionSource)) &&
+            (identical(other.partOfSpeech, partOfSpeech) ||
+                const DeepCollectionEquality()
+                    .equals(other.partOfSpeech, partOfSpeech)) &&
             (identical(other.word, word) ||
                 const DeepCollectionEquality().equals(other.word, word)) &&
             (identical(other.definition, definition) ||
@@ -935,6 +970,7 @@ class DefinitionContentItemW {
       const DeepCollectionEquality().hash(language) ^
       const DeepCollectionEquality().hash(sourceLink) ^
       const DeepCollectionEquality().hash(definitionSource) ^
+      const DeepCollectionEquality().hash(partOfSpeech) ^
       const DeepCollectionEquality().hash(word) ^
       const DeepCollectionEquality().hash(definition) ^
       const DeepCollectionEquality().hash(entry) ^
@@ -946,6 +982,7 @@ extension $DefinitionContentItemWExtension on DefinitionContentItemW {
       {Language? language,
       String? sourceLink,
       int? definitionSource,
+      enums.PartOfSpeech? partOfSpeech,
       String? word,
       String? definition,
       int? entry}) {
@@ -953,6 +990,7 @@ extension $DefinitionContentItemWExtension on DefinitionContentItemW {
         language: language ?? this.language,
         sourceLink: sourceLink ?? this.sourceLink,
         definitionSource: definitionSource ?? this.definitionSource,
+        partOfSpeech: partOfSpeech ?? this.partOfSpeech,
         word: word ?? this.word,
         definition: definition ?? this.definition,
         entry: entry ?? this.entry);
@@ -1235,6 +1273,7 @@ class DefinitionContentItem {
     this.id,
     this.sourceLink,
     this.definitionSource,
+    this.partOfSpeech,
     this.word,
     this.definition,
     this.entry,
@@ -1251,6 +1290,11 @@ class DefinitionContentItem {
   final String? sourceLink;
   @JsonKey(name: 'definitionSource')
   final int? definitionSource;
+  @JsonKey(
+      name: 'partOfSpeech',
+      toJson: partOfSpeechToJson,
+      fromJson: partOfSpeechFromJson)
+  final enums.PartOfSpeech? partOfSpeech;
   @JsonKey(name: 'word')
   final String? word;
   @JsonKey(name: 'definition')
@@ -1276,6 +1320,9 @@ class DefinitionContentItem {
             (identical(other.definitionSource, definitionSource) ||
                 const DeepCollectionEquality()
                     .equals(other.definitionSource, definitionSource)) &&
+            (identical(other.partOfSpeech, partOfSpeech) ||
+                const DeepCollectionEquality()
+                    .equals(other.partOfSpeech, partOfSpeech)) &&
             (identical(other.word, word) ||
                 const DeepCollectionEquality().equals(other.word, word)) &&
             (identical(other.definition, definition) ||
@@ -1291,6 +1338,7 @@ class DefinitionContentItem {
       const DeepCollectionEquality().hash(id) ^
       const DeepCollectionEquality().hash(sourceLink) ^
       const DeepCollectionEquality().hash(definitionSource) ^
+      const DeepCollectionEquality().hash(partOfSpeech) ^
       const DeepCollectionEquality().hash(word) ^
       const DeepCollectionEquality().hash(definition) ^
       const DeepCollectionEquality().hash(entry) ^
@@ -1303,6 +1351,7 @@ extension $DefinitionContentItemExtension on DefinitionContentItem {
       int? id,
       String? sourceLink,
       int? definitionSource,
+      enums.PartOfSpeech? partOfSpeech,
       String? word,
       String? definition,
       int? entry}) {
@@ -1311,6 +1360,7 @@ extension $DefinitionContentItemExtension on DefinitionContentItem {
         id: id ?? this.id,
         sourceLink: sourceLink ?? this.sourceLink,
         definitionSource: definitionSource ?? this.definitionSource,
+        partOfSpeech: partOfSpeech ?? this.partOfSpeech,
         word: word ?? this.word,
         definition: definition ?? this.definition,
         entry: entry ?? this.entry);
@@ -1573,6 +1623,49 @@ extension $UserStatisticsRExtension on UserStatisticsR {
     return UserStatisticsR(
         apiKey: apiKey ?? this.apiKey, languages: languages ?? this.languages);
   }
+}
+
+String? partOfSpeechToJson(enums.PartOfSpeech? partOfSpeech) {
+  return enums.$PartOfSpeechMap[partOfSpeech];
+}
+
+enums.PartOfSpeech partOfSpeechFromJson(Object? partOfSpeech) {
+  if (partOfSpeech is int) {
+    return enums.$PartOfSpeechMap.entries
+        .firstWhere(
+            (element) => element.value.toLowerCase() == partOfSpeech.toString(),
+            orElse: () =>
+                const MapEntry(enums.PartOfSpeech.swaggerGeneratedUnknown, ''))
+        .key;
+  }
+
+  if (partOfSpeech is String) {
+    return enums.$PartOfSpeechMap.entries
+        .firstWhere(
+            (element) =>
+                element.value.toLowerCase() == partOfSpeech.toLowerCase(),
+            orElse: () =>
+                const MapEntry(enums.PartOfSpeech.swaggerGeneratedUnknown, ''))
+        .key;
+  }
+
+  return enums.PartOfSpeech.swaggerGeneratedUnknown;
+}
+
+List<String> partOfSpeechListToJson(List<enums.PartOfSpeech>? partOfSpeech) {
+  if (partOfSpeech == null) {
+    return [];
+  }
+
+  return partOfSpeech.map((e) => enums.$PartOfSpeechMap[e]!).toList();
+}
+
+List<enums.PartOfSpeech> partOfSpeechListFromJson(List? partOfSpeech) {
+  if (partOfSpeech == null) {
+    return [];
+  }
+
+  return partOfSpeech.map((e) => partOfSpeechFromJson(e.toString())).toList();
 }
 
 typedef $JsonFactory<T> = T Function(Map<String, dynamic> json);

--- a/lib/swagger_generated_code/orditori.swagger.g.dart
+++ b/lib/swagger_generated_code/orditori.swagger.g.dart
@@ -52,6 +52,7 @@ DefinitionContentItemR _$DefinitionContentItemRFromJson(
       id: json['id'] as int?,
       sourceLink: json['sourceLink'] as String?,
       definitionSource: json['definitionSource'] as int?,
+      partOfSpeech: partOfSpeechFromJson(json['partOfSpeech']),
       word: json['word'] as String?,
       definition: json['definition'] as String?,
       examples: (json['examples'] as List<dynamic>?)
@@ -68,6 +69,7 @@ Map<String, dynamic> _$DefinitionContentItemRToJson(
       'id': instance.id,
       'sourceLink': instance.sourceLink,
       'definitionSource': instance.definitionSource,
+      'partOfSpeech': partOfSpeechToJson(instance.partOfSpeech),
       'word': instance.word,
       'definition': instance.definition,
       'examples': instance.examples?.map((e) => e.toJson()).toList(),
@@ -136,6 +138,7 @@ Definition _$DefinitionFromJson(Map<String, dynamic> json) => Definition(
           ? null
           : Language.fromJson(json['language'] as Map<String, dynamic>),
       sourceLink: json['sourceLink'] as String?,
+      partOfSpeech: partOfSpeechFromJson(json['partOfSpeech']),
       word: json['word'] as String?,
       definition: json['definition'] as String?,
       examples: (json['examples'] as List<dynamic>?)
@@ -148,6 +151,7 @@ Map<String, dynamic> _$DefinitionToJson(Definition instance) =>
     <String, dynamic>{
       'language': instance.language?.toJson(),
       'sourceLink': instance.sourceLink,
+      'partOfSpeech': partOfSpeechToJson(instance.partOfSpeech),
       'word': instance.word,
       'definition': instance.definition,
       'examples': instance.examples?.map((e) => e.toJson()).toList(),
@@ -201,6 +205,7 @@ DefinitionContentItemW _$DefinitionContentItemWFromJson(
           : Language.fromJson(json['language'] as Map<String, dynamic>),
       sourceLink: json['sourceLink'] as String?,
       definitionSource: json['definitionSource'] as int?,
+      partOfSpeech: partOfSpeechFromJson(json['partOfSpeech']),
       word: json['word'] as String?,
       definition: json['definition'] as String?,
       entry: json['entry'] as int?,
@@ -212,6 +217,7 @@ Map<String, dynamic> _$DefinitionContentItemWToJson(
       'language': instance.language?.toJson(),
       'sourceLink': instance.sourceLink,
       'definitionSource': instance.definitionSource,
+      'partOfSpeech': partOfSpeechToJson(instance.partOfSpeech),
       'word': instance.word,
       'definition': instance.definition,
       'entry': instance.entry,
@@ -311,6 +317,7 @@ DefinitionContentItem _$DefinitionContentItemFromJson(
       id: json['id'] as int?,
       sourceLink: json['sourceLink'] as String?,
       definitionSource: json['definitionSource'] as int?,
+      partOfSpeech: partOfSpeechFromJson(json['partOfSpeech']),
       word: json['word'] as String?,
       definition: json['definition'] as String?,
       entry: json['entry'] as int?,
@@ -323,6 +330,7 @@ Map<String, dynamic> _$DefinitionContentItemToJson(
       'id': instance.id,
       'sourceLink': instance.sourceLink,
       'definitionSource': instance.definitionSource,
+      'partOfSpeech': partOfSpeechToJson(instance.partOfSpeech),
       'word': instance.word,
       'definition': instance.definition,
       'entry': instance.entry,


### PR DESCRIPTION
Let's display part of speech for the definitions that have one

`PartOfSpeech.swaggerGeneratedUnknown` is a bit weird.

What it looks like:

<img width="343" alt="image" src="https://user-images.githubusercontent.com/669784/167435202-97863a41-05aa-4843-b418-28f4dd0d6a49.png">

